### PR TITLE
class_faiTemplateEntry.inc: Use get_uid_regexp() instead having our o…

### DIFF
--- a/admin/fai/class_faiTemplateEntry.inc
+++ b/admin/fai/class_faiTemplateEntry.inc
@@ -254,11 +254,7 @@ class faiTemplateEntry extends plugin
     if($this->group == ""){
       $message[] = msgPool::required(_("Group"));
     }elseif (!tests::is_uid($this->group)){
-      if (strict_uid_mode()){
-        $message[]= msgPool::invalid(_("Group"), $this->group, "/[a-z0-9_-]/");
-      } else {
-        $message[]= msgPool::invalid(_("Group"), $this->group, "/[a-z0-9_-]/i");
-      }
+      $message[]= msgPool::invalid(_("Group"), $this->group, "/".get_uid_regexp()."/");
     }
 
     return ($message);


### PR DESCRIPTION
…wn regexp.

This patch goes together with a patch for gosa-core, provided here: https://github.com/sunweaver/gosa-core/commit/98da3e59670c0989bc30cc20ae9f5b1c922a18d1
